### PR TITLE
Step 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,17 @@ Basically dump some input file out as "hex" like `xxd` does
 - also got to be a better way to conver a byte into a char for concat into a string. I do need to do that one byte at a time for printable character reasons, but that's a lot of iterating
 - Basically feeling like it works but is sub optimal - although the examples I've looked at basically do what the codes doing. Who knows
 
+## Step 2
+
+This step is about supporting the -e ([little-endian](https://en.wikipedia.org/wiki/Endianness)) flag and -g (group) option
+
+- `ArgumentParser` library should come in handy here. Probably use some of the more specific syntax
+- Grouping should already be done through the "chunking" call
+- I'll need to come up with a strategy for converting to the `[UInt8]` chunks by swapping around bytes based on the chunk size
+    - will also need to validate that the "group" is divisible by 2 if the endian option is used
+
+### Notes
+- added flags and options to the command line to handle the input
+- the grouping was pretty easy since I already had the chunking figured out
+- ended up writing a `toLittleEndian()` extension for `[UInt8]` and added a if statement to handle the flag
+- 

--- a/xxd/Array+Extensions.swift
+++ b/xxd/Array+Extensions.swift
@@ -7,10 +7,19 @@
 
 import Foundation
 
-// takes an array of UInt8 elements, converts each element to hex and then concats all of them together
 extension Array where Element == UInt8 {
-    func toHexString() -> String {
+    // takes an array of UInt8 elements, converts each element to hex and then concats all of them together into a string
+   func toHexString() -> String {
         return self.map { String(format: "%02x", $0) }.joined()
+    }
+    
+    // convert a array of UInt8s to little endian format
+    func toLittleEndian() -> [UInt8] {
+        var result = [UInt8](repeating: 0, count: self.count)
+        for (index, byte) in self.enumerated() {
+            result[self.count - 1 - index] = byte
+        }
+        return result
     }
 }
 

--- a/xxd/SwiftXXD.swift
+++ b/xxd/SwiftXXD.swift
@@ -11,29 +11,65 @@ import ArgumentParser
 
 @main
 struct SwiftXXD : ParsableCommand {
-    @Argument var filename: String
-
     static let kDefaultDataSize = 16
-    static let kDefaultGroupSize = 4
+    
+    static let kDefaultGroupSize = 2
+    static let kDefaultEndianGroupSize = 4
 
     static let kDefaultFileOffset : UInt64 = 0
     static let kDefaultDataIncrementSize : UInt64 = UInt64(kDefaultDataSize)
 
+    @Argument var filename: String
+    @Option(name: .shortAndLong)
+    var groupsize : Int?
+    
+    @Flag(name: .short)
+    var endian : Bool = false
+
+
     func run() throws {
+        
+        // little endian format has a different default group size than big-endian. Set accordingly and check for incompatable values
+        var theGroupSize : Int
+        if (endian) {
+            theGroupSize = groupsize ?? SwiftXXD.kDefaultEndianGroupSize
+            
+            // must be a power of 2 for [little endian](https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2)
+            if !((theGroupSize != 0) && ((theGroupSize & (theGroupSize - 1)) == 0)) {
+                print("swift-xdd: number of octets per group must be a power of 2 with -e.")
+                return
+            }
+        } else {
+            theGroupSize = groupsize ?? SwiftXXD.kDefaultGroupSize
+            
+            // ensure that the group size doesn't exceed the max. xxd just goes on by setting it to the max
+            theGroupSize = theGroupSize > SwiftXXD.kDefaultDataSize ? SwiftXXD.kDefaultDataSize : theGroupSize
+        }
+        
+        // start reading from the file..
         do {
             let fileHandle = try FileHandle(forReadingFrom: URL(fileURLWithPath: filename))
             
+            // assume we start at zero unless otherwise indicated
             var fileOffset = SwiftXXD.kDefaultFileOffset
             if (fileOffset > 0) {
                 try fileHandle.seek(toOffset: fileOffset)
             }
             
+            // read in the next chunk
             while let values = fileHandle.readUInt8s(ofSize: SwiftXXD.kDefaultDataSize) {
+                // create the ASCII view
                 let theView = String(values)
+                
+                // create the offset value
                 let theOffset = String(format: "%08X", fileOffset)
                 
-                let theLine = values.chunked(into: SwiftXXD.kDefaultGroupSize).map { $0.toHexString() }.joined(separator: " ")
+                // create the line of hex data in the approperiate chunks in the correct format
+                let theLine = endian
+                    ? values.chunked(into: theGroupSize).map { $0.toLittleEndian().toHexString() }.joined(separator: " ")
+                    : values.chunked(into: theGroupSize).map { $0.toHexString() }.joined(separator: " ")
 
+                // write all the data out in xxd format
                 print("\(theOffset): \(theLine)  \(theView)")
                 fileOffset += SwiftXXD.kDefaultDataIncrementSize
             }
@@ -42,6 +78,7 @@ struct SwiftXXD : ParsableCommand {
             
         } catch {
             print("Error reading file: \(error)")
+            MyLogger.log.error("\(error)")
         }
     }
 }

--- a/xxdTest/xxdTest.swift
+++ b/xxdTest/xxdTest.swift
@@ -63,4 +63,19 @@ final class xxdTest: XCTestCase {
         let theBytes = xxdTest.kData.hexaBytes
         XCTAssertEqual(String(theBytes), xxdTest.kAsciiData)
     }
+    
+    func testLittleEndian() throws {
+        let theBytes = xxdTest.kData.hexaBytes
+        var theGroups = theBytes.chunked(into: 2)
+        
+        XCTAssertEqual(theGroups.count, 8)
+        XCTAssertEqual(theGroups[0].toLittleEndian().toHexString(), "0178")
+        XCTAssertEqual(theGroups[1].toLittleEndian().toHexString(), "d0ed")
+        XCTAssertEqual(theGroups[2].toLittleEndian().toHexString(), "09b1")
+        XCTAssertEqual(theGroups[7].toLittleEndian().toHexString(), "c35f")
+
+        theGroups = theBytes.chunked(into: 4)
+        XCTAssertEqual(theGroups[0].toLittleEndian().toHexString(), "d0ed0178")
+        XCTAssertEqual(theGroups[1].toLittleEndian().toHexString(), "200009b1")
+    }
 }


### PR DESCRIPTION
Step 2 was all about adding options for viewing in different groups and in little-endian format
- took advantage of the `ArgumentParser` library to handle the `-g` option and `-e` flag
- wrote a toLittleEndian() function for swapping UInt8 bytes around in an array
- updated command line processing to look for improper grouping and/or endian settings
- 