### PR TITLE
Step 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,10 @@ This step is about supporting the -e ([little-endian](https://en.wikipedia.org/w
 - the grouping was pretty easy since I already had the chunking figured out
 - ended up writing a `toLittleEndian()` extension for `[UInt8]` and added a if statement to handle the flag
 - 
+
+## Step 3
+
+> support the command line options to set the number of octets to be written out and the number of columns to print per line. These are the -l and -c flags [if] you want to explore the valid settings in the man entry.
+
+- Added `OctetCounter` to help with octet bookkeeping
+    - need to figure out how to pad for "length"

--- a/README.md
+++ b/README.md
@@ -94,5 +94,15 @@ This step is about supporting the -e ([little-endian](https://en.wikipedia.org/w
 
 > support the command line options to set the number of octets to be written out and the number of columns to print per line. These are the -l and -c flags [if] you want to explore the valid settings in the man entry.
 
-- Added `OctetCounter` to help with octet bookkeeping
-    - need to figure out how to pad for "length"
+- the "len" option is just how many total octets to read from the file
+    - Added `OctetCounter` to help with octet bookkeeping
+    - Adding padding to the hex output so incomplete lines will line up
+
+- the "col" option is how many octets to read at once.
+    - up to this point, 16's been the default column size so that needs to become flexible
+    - `OctetCounter` now controls the size of the read, which is the number of "cols"
+
+### Notes
+- again, given the existing structure, this wasn't all that much of a change. Mainly rerouting some constants already in use.
+- consolidating the logic in the `OctetCounter` make it pretty easy
+- not sure I have the logic right between `-g`, `-e` and `-c` but the standard `xxd` seems to ignore `-g` when `-c` is in use

--- a/xxd.xcodeproj/project.pbxproj
+++ b/xxd.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		396DFB102BBC62410039DB26 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DFB0F2BBC62410039DB26 /* String+Extensions.swift */; };
 		396DFB112BBC75490039DB26 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DFB0D2BBC4C100039DB26 /* Array+Extensions.swift */; };
 		396DFB122BBC95990039DB26 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DFB0F2BBC62410039DB26 /* String+Extensions.swift */; };
+		396DFB142BBCD19F0039DB26 /* OctetCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DFB132BBCD19F0039DB26 /* OctetCounter.swift */; };
+		396DFB162BBCD9B60039DB26 /* OctetCounterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DFB152BBCD9B60039DB26 /* OctetCounterTest.swift */; };
+		396DFB172BBCD9C70039DB26 /* OctetCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DFB132BBCD19F0039DB26 /* OctetCounter.swift */; };
 		39EE0E132BBA397A0005A3EE /* xxdTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EE0E122BBA397A0005A3EE /* xxdTest.swift */; };
 		39EE0E1A2BBA3A8C0005A3EE /* SwiftXXD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EE0E192BBA3A8C0005A3EE /* SwiftXXD.swift */; };
 		39EE0E1D2BBA3ACE0005A3EE /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = 39EE0E1C2BBA3ACE0005A3EE /* ArgumentParser */; };
@@ -33,6 +36,8 @@
 		392CD4BB2BBB883000EF5C0F /* FileManager+FileReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+FileReading.swift"; sourceTree = "<group>"; };
 		396DFB0D2BBC4C100039DB26 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		396DFB0F2BBC62410039DB26 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
+		396DFB132BBCD19F0039DB26 /* OctetCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OctetCounter.swift; sourceTree = "<group>"; };
+		396DFB152BBCD9B60039DB26 /* OctetCounterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OctetCounterTest.swift; sourceTree = "<group>"; };
 		39BAED672BBA3F3F0042270F /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		39EE0DF72BBA38F00005A3EE /* xxd */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = xxd; sourceTree = BUILT_PRODUCTS_DIR; };
 		39EE0E102BBA397A0005A3EE /* xxdTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = xxdTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -85,6 +90,7 @@
 				392CD4BB2BBB883000EF5C0F /* FileManager+FileReading.swift */,
 				396DFB0D2BBC4C100039DB26 /* Array+Extensions.swift */,
 				396DFB0F2BBC62410039DB26 /* String+Extensions.swift */,
+				396DFB132BBCD19F0039DB26 /* OctetCounter.swift */,
 			);
 			path = xxd;
 			sourceTree = "<group>";
@@ -93,6 +99,7 @@
 			isa = PBXGroup;
 			children = (
 				39EE0E122BBA397A0005A3EE /* xxdTest.swift */,
+				396DFB152BBCD9B60039DB26 /* OctetCounterTest.swift */,
 			);
 			path = xxdTest;
 			sourceTree = "<group>";
@@ -196,6 +203,7 @@
 				396DFB0E2BBC4C100039DB26 /* Array+Extensions.swift in Sources */,
 				39EE0E1A2BBA3A8C0005A3EE /* SwiftXXD.swift in Sources */,
 				396DFB102BBC62410039DB26 /* String+Extensions.swift in Sources */,
+				396DFB142BBCD19F0039DB26 /* OctetCounter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -203,9 +211,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				396DFB162BBCD9B60039DB26 /* OctetCounterTest.swift in Sources */,
 				39EE0E132BBA397A0005A3EE /* xxdTest.swift in Sources */,
 				396DFB122BBC95990039DB26 /* String+Extensions.swift in Sources */,
 				396DFB112BBC75490039DB26 /* Array+Extensions.swift in Sources */,
+				396DFB172BBCD9C70039DB26 /* OctetCounter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/xxd/OctetCounter.swift
+++ b/xxd/OctetCounter.swift
@@ -12,21 +12,31 @@ import Foundation
 
 struct OctetCounter {
     public static let kNoLength = -1
-    public static let kDefaultOctetCount = 16
+    public static let kDefaultOctetSize = 16
         
     private var maxOctetCount : Int = OctetCounter.kNoLength
     private var octetCount : Int = 0
+    private var _octextSize : Int = OctetCounter.kDefaultOctetSize
     
-    init(max inMaxOctet: Int) {
-        self.maxOctetCount = inMaxOctet
+    public init(max inMaxOctets: Int) {
+        self.maxOctetCount = inMaxOctets
     }
 
+    public init(max inMaxOctets: Int, size inOctetSize: Int) {
+        self.maxOctetCount = inMaxOctets
+        self._octextSize = inOctetSize
+    }
+
+    public var octextSize: Int {
+        return self._octextSize
+    }
+    
     public mutating func incrementOctetsRead(by inAmount: Int) {
         self.octetCount += inAmount;
     }
     
     public func octetsToRead() -> Int {
-        var result = OctetCounter.kDefaultOctetCount
+        var result = self._octextSize
         if (maxOctetCount != OctetCounter.kNoLength) {
             if (octetCount < maxOctetCount) {
                 result = maxOctetCount - octetCount > result ? result : maxOctetCount - octetCount

--- a/xxd/OctetCounter.swift
+++ b/xxd/OctetCounter.swift
@@ -1,0 +1,39 @@
+//
+//  OctetCounter.swift
+//  xxd
+//
+//  Created by Matthew Axsom on 4/2/24.
+//
+
+import Foundation
+
+// keeps track of the number of Octets read and calculates how many can be read the next time based on a max
+// if no max it's alwasy the default count
+
+struct OctetCounter {
+    public static let kNoLength = -1
+    public static let kDefaultOctetCount = 16
+        
+    private var maxOctetCount : Int = OctetCounter.kNoLength
+    private var octetCount : Int = 0
+    
+    init(max inMaxOctet: Int) {
+        self.maxOctetCount = inMaxOctet
+    }
+
+    public mutating func incrementOctetsRead(by inAmount: Int) {
+        self.octetCount += inAmount;
+    }
+    
+    public func octetsToRead() -> Int {
+        var result = OctetCounter.kDefaultOctetCount
+        if (maxOctetCount != OctetCounter.kNoLength) {
+            if (octetCount < maxOctetCount) {
+                result = maxOctetCount - octetCount > result ? result : maxOctetCount - octetCount
+            } else {
+                result = 0
+            }
+        }
+        return result
+    }
+}

--- a/xxd/SwiftXXD.swift
+++ b/xxd/SwiftXXD.swift
@@ -55,6 +55,12 @@ struct SwiftXXD : ParsableCommand {
             theGroupSize = theGroupSize > OctetCounter.kDefaultOctetCount ? OctetCounter.kDefaultOctetCount : theGroupSize
         }
         
+        // calculate the length "hex" field in terms of characters so we can pad if necessary
+        var theHexFieldLen = 32 + (OctetCounter.kDefaultOctetCount/theGroupSize)
+        if (OctetCounter.kDefaultOctetCount % theGroupSize == 0) {
+            theHexFieldLen -= 1
+        }
+        
         // initialize our
         var theOctetCounter = OctetCounter(max: len ?? OctetCounter.kNoLength)
         
@@ -86,7 +92,8 @@ struct SwiftXXD : ParsableCommand {
                     : values.chunked(into: theGroupSize).map { $0.toHexString() }.joined(separator: " ")
 
                 // write all the data out in xxd format
-                print("\(theOffset): \(theLine)  \(theView)")
+                print("\(theOffset): \(theLine.padding(toLength: theHexFieldLen, withPad: " ", startingAt: 0))  \(theView)")
+                
                 fileOffset += SwiftXXD.kDefaultDataIncrementSize
                 
                 theOctetsToRead = theOctetCounter.octetsToRead()

--- a/xxdTest/OctetCounterTest.swift
+++ b/xxdTest/OctetCounterTest.swift
@@ -1,0 +1,38 @@
+//
+//  OctetCounterTest.swift
+//  xxdTest
+//
+//  Created by Matthew Axsom on 4/2/24.
+//
+
+import XCTest
+
+final class OctetCounterTest : XCTestCase {
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testOctetCounter() throws {
+        var theCounter = OctetCounter(max: OctetCounter.kNoLength)
+        XCTAssertEqual(theCounter.octetsToRead(), OctetCounter.kDefaultOctetCount)
+        
+        theCounter = OctetCounter(max: 10)
+        XCTAssertEqual(theCounter.octetsToRead(), 10)
+        
+        theCounter = OctetCounter(max: 30)
+        XCTAssertEqual(theCounter.octetsToRead(), OctetCounter.kDefaultOctetCount)
+        theCounter.incrementOctetsRead(by: OctetCounter.kDefaultOctetCount)
+        XCTAssertEqual(theCounter.octetsToRead(), 14)
+        theCounter.incrementOctetsRead(by: 14)
+        XCTAssertEqual(theCounter.octetsToRead(), 0)
+        
+        // test beyond end
+        theCounter.incrementOctetsRead(by: 32)
+        XCTAssertEqual(theCounter.octetsToRead(), 0)
+    }
+}
+


### PR DESCRIPTION
Added options for `-c` and `-l` flags
- `OctetCounter` is "home" for managing those setting
- can limit number of total octets read with `-l`
- can elect to display the number of octets in the "hex" field with `-c`